### PR TITLE
Add utility script to overwrite RESTART fields from FV3-JEDI analysis

### DIFF
--- a/UFS-DA/ush/update_restart.py
+++ b/UFS-DA/ush/update_restart.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/UFS-DA/ush/update_restart.py
+++ b/UFS-DA/ush/update_restart.py
@@ -1,1 +1,60 @@
 #!/usr/bin/env python3
+import click
+import netCDF4 as nc
+
+# list of fields to ignore
+ignore_vars = [
+    'xaxis_1',
+    'yaxis_1',
+    'zaxis_1',
+    'Time',
+    ]
+
+@click.command()
+@click.argument('analysis', type=click.Path(exists=True))
+@click.argument('restart', type=click.Path(exists=True))
+def run_update_restart(analysis, restart):
+    """
+    run_update_restart(analysis, restart)
+    replace fields in `restart` with those
+    from `analysis`
+    Both arguments must be paths to FV3 tiled RESTART files
+    """
+    # open both netCDF files
+    anl = nc.Dataset(analysis, 'r')
+    rst = nc.Dataset(restart, 'a')
+
+    # check that dimensions match
+    check_dims(anl, rst)
+
+    # loop through variables now
+    for ncv in anl.variables:
+        if ncv in ignore_vars:
+            continue
+        if ncv not in rst.variables:
+            raise KeyError(f"Variable {ncv} not in both files")
+        data = anl.variables[ncv][:]
+        outvar = rst.variables[ncv]
+        outvar[:] = data
+
+    # close the files and flush to disk
+    anl.close()
+    rst.close()
+
+
+def check_dims(file1, file2):
+    """
+    check to ensure that dimensions of both files
+    are the same name, quantity, and of equal size
+    """
+    for dim in file1.dimensions.values():
+        if dim.name not in file2.dimensions:
+            raise KeyError(f"Dimension {dim.name} not in both files")
+        size1 = dim.size
+        size2 = file2.dimensions[dim.name].size
+        if size1 != size2:
+            raise ValueError(f"Size mismatch for {dim.name}: {size1} != {size2}")
+
+
+if __name__ == '__main__':
+    run_update_restart()

--- a/UFS-DA/ush/update_restart.py
+++ b/UFS-DA/ush/update_restart.py
@@ -21,26 +21,20 @@ def run_update_restart(analysis, restart):
     from `analysis`
     Both arguments must be paths to FV3 tiled RESTART files
     """
-    # open both netCDF files
-    anl = nc.Dataset(analysis, 'r')
-    rst = nc.Dataset(restart, 'a')
+    with nc.Dataset(analysis, 'r') as anl, nc.Dataset(restart, 'a') as rst:
+        # check that dimensions match
+        check_dims(anl, rst)
 
-    # check that dimensions match
-    check_dims(anl, rst)
-
-    # loop through variables now
-    for ncv in anl.variables:
-        if ncv in ignore_vars:
-            continue
-        if ncv not in rst.variables:
-            raise KeyError(f"Variable {ncv} not in both files")
-        data = anl.variables[ncv][:]
-        outvar = rst.variables[ncv]
-        outvar[:] = data
-
-    # close the files and flush to disk
-    anl.close()
-    rst.close()
+        # loop through variables now
+        for ncv in anl.variables:
+            if ncv in ignore_vars:
+                continue
+            if ncv not in rst.variables:
+                raise KeyError(f"Variable {ncv} not in both files")
+                
+            data = anl.variables[ncv][:]
+            outvar = rst.variables[ncv]
+            outvar[:] = data
 
 
 def check_dims(file1, file2):

--- a/UFS-DA/ush/update_restart.py
+++ b/UFS-DA/ush/update_restart.py
@@ -10,6 +10,7 @@ ignore_vars = [
     'Time',
     ]
 
+
 @click.command()
 @click.argument('analysis', type=click.Path(exists=True))
 @click.argument('restart', type=click.Path(exists=True))


### PR DESCRIPTION
Closes #8 

This adds a utility python script to overwrite FV3 RESTART fields using arrays from a FV3-JEDI analysis file in the FV3 RESTART format.