### PR TITLE
Update feature/gdas-validation to be consistent with g-w and JEDI changes

### DIFF
--- a/GDAS-validation/gdas_config/3dvar_dripcg.yaml
+++ b/GDAS-validation/gdas_config/3dvar_dripcg.yaml
@@ -1,7 +1,8 @@
 cost function:
   cost type: 3D-Var
-  window begin: '{{ ATM_WINDOW_BEGIN | to_isotime }}'
-  window length: $(ATM_WINDOW_LENGTH)
+  time window:
+    begin: '{{ ATM_WINDOW_BEGIN | to_isotime }}'
+    length: $(ATM_WINDOW_LENGTH)
   analysis variables: &3dvars [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]
   geometry:
     fms initialization:

--- a/GDAS-validation/gdas_config/config.anal
+++ b/GDAS-validation/gdas_config/config.anal
@@ -147,6 +147,7 @@ fi
 
 # GSI configuration
 export USE_RADSTAT="NO" # This can be only used when bias correction is not-zero.
+export USE_CORRELATED_OBERRS="NO"
 export SETUP="miter=0,nhr_obsbin=6,gpstop=55.,thin4d=.true.,${SETUP:-}"
 export imp_physics=11
 export cao_check=".false."
@@ -156,7 +157,13 @@ export OBSQC="c_varqc=0.04,nvqc=.false.,${OBQC:-}"
 export NST_GSI=0
 
 # Use specific versions of info files
-export GSIFIX=/work2/noaa/da/cmartin/UFO_eval/geovals/GSI/fix
+if [[ "${machine}" = "ORION" ]]; then
+    export GSIFIX=/work2/noaa/da/cmartin/UFO_eval/geovals/GSI/fix
+    export CRTM_FIX=/work2/noaa/da/cmartin/GDASApp/fix/crtm/2.4.0
+elif [[ ${machine} = "HERA" ]]; then
+    export GSIFIX=/scratch1/NCEPDEV/da/Cory.R.Martin/UFO_eval/geovals/GSI/fix
+    export CRTM_FIX=/scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/fix/crtm/2.4.0
+fi
 export ANAVINFO=$GSIFIX/global_anavinfo.l127.txt
 export CONVINFO=$GSIFIX/global_convinfo.txt
 export OZINFO=$GSIFIX/global_ozinfo.txt
@@ -190,6 +197,10 @@ export ATMSDB=/dev/null
 export BERROR=${GSIFIX}/Big_Endian/global_berror.l127y1538.f77
 
 # Add CRTM to library path
-export LD_LIBRARY_PATH=/work/noaa/da/eliu/JEDI-GDAS/crtm_v2.4.1-jedi.1-intel2022/build/lib:${LD_LIBRARY_PATH}
+if [[ "${machine}" = "ORION" ]]; then
+    export LD_LIBRARY_PATH=/work/noaa/da/eliu/JEDI-GDAS/crtm_v2.4.1-jedi.1-intel2022/build/lib:${LD_LIBRARY_PATH}
+elif [[ ${machine} = "HERA" ]]; then
+    export LD_LIBRARY_PATH=/scratch1/NCEPDEV/da/Emily.Liu/JEDI-GDAS/crtm-v2.4.1-jedi.1-intel/build/lib:${LD_LIBRARY_PATH}
+fi
 
 echo "END: config.anal"

--- a/GDAS-validation/gdas_config/config.atmanl
+++ b/GDAS-validation/gdas_config/config.atmanl
@@ -6,6 +6,7 @@
 echo "BEGIN: config.atmanl"
 
 export CASE_ANL=${CASE}
+#export CASE_ANL=C384
 export OBS_YAML_DIR=${HOMEgfs}/sorc/gdas.cd/parm/atm/obs/config/
 export OBS_LIST=${HOMEgfs}/sorc/gdas.cd/parm/atm/obs/lists/gdas_prototype_3d.yaml
 export ATMVARYAML=${HOMEgfs}/sorc/gdas.cd/parm/atm/variational/3dvar_dripcg.yaml

--- a/GDAS-validation/gdas_config/config.resources
+++ b/GDAS-validation/gdas_config/config.resources
@@ -223,9 +223,11 @@ elif [[ "${step}" = "atmanlrun" ]]; then
     export npe_atmanlrun_gfs
     export nth_atmanlrun=1
     export nth_atmanlrun_gfs=${nth_atmanlrun}
-    npe_node_atmanlrun=$(echo "${npe_node_max} / ${nth_atmanlrun}" | bc)
+    #npe_node_atmanlrun=$(echo "${npe_node_max} / ${nth_atmanlrun}" | bc)
+    npe_node_atmanlrun=10
     export npe_node_atmanlrun
     export is_exclusive=True
+    export memory_atmanlrun="90GB"
 
 elif [[ "${step}" = "atmanlfinal" ]]; then
 

--- a/GDAS-validation/gdas_config/config.resources
+++ b/GDAS-validation/gdas_config/config.resources
@@ -55,6 +55,8 @@ elif [[ "${machine}" = "AWSPW" ]]; then
      export npe_node_max=40
 elif [[ ${machine} = "ORION" ]]; then
    export npe_node_max=40
+elif [[ ${machine} = "HERCULES" ]]; then
+   export npe_node_max=40
 fi
 
 if [[ ${step} = "prep" ]]; then
@@ -77,7 +79,7 @@ elif [[ "${step}" = "preplandobs" ]]; then
     export npe_node_preplandobs
 
 elif [[ "${step}" = "prepatmiodaobs" ]]; then
-    export wtime_prepatmiodaobs="00:10:00"
+    export wtime_prepatmiodaobs="00:30:00"
     export npe_prepatmiodaobs=1
     export nth_prepatmiodaobs=1
     npe_node_prepatmiodaobs=$(echo "${npe_node_max} / ${nth_prepatmiodaobs}" | bc)
@@ -462,8 +464,9 @@ elif [[ ${step} = "anal" ]]; then
     export wtime_anal="00:50:00"
     export wtime_anal_gfs="00:40:00"
     export npe_anal=84
+    export nth_anal=10
     #export npe_anal=780
-    export nth_anal=5
+    #export nth_anal=5
     export npe_anal_gfs=825
     export nth_anal_gfs=5
     if [[ "${machine}" = "WCOSS2" ]]; then
@@ -729,7 +732,7 @@ elif [[ ${step} = "verfozn" ]]; then
 
 elif [[ ${step} = "verfrad" ]]; then
 
-    export wtime_verfrad="00:20:00"
+    export wtime_verfrad="00:40:00"
     export npe_verfrad=1
     export nth_verfrad=1
     export npe_node_verfrad=1


### PR DESCRIPTION
g-w and JEDI have been updated and this requires corresponding updates in `feature/gdas-validation`.  This PR adds the required updates to `feature/gdas-validation`.  Changes are also made which allow GDAS validation to run on Hera in addition to Orion.

Fixes #105

GSI and JEDI GDAS validation were run on Orion and Hera for 2021080100.  GSI prep, anal, and analdiag jobs ran to completion.  JEDI prepatmiodaobs, atmanlinit, atmanlrun, and atmanlfinal ran to completion.

JEDI testing was done with the following local changes:
- edit `parm/atm/obs/lists/gdas_prototype_3d.yaml` to process atms_n20, satwind_abi_goes-16, scatwind_ascat_metop-a, and gnssro
- move `ush/ioda/bufr2ioda/bufr2ioda_subpfl_argo_profiles.py` to `ush/ioda/bufr2ioda/skip_bufr2ioda_subpfl_argo_profiles.py` to prevent this script from being executed by `run_bufr2ioda.py`.  The bufr dump file processed by `bufr2ioda_subpfl_argo_profiles.py` does not exist in the `DMPDIR` for atmospheric observations.   Hence `bufr2ioda_subpfl_argo_profiles.py` aborts.  The proposed solution is to change `run_bufr2ioda.py` so that it reads a list of observation dump files to process instead of running all scripts which begin with `bufr2ioda`.  This change will be in a future GDASApp PR.
- set `CASE_ANL=C384` in `config.atmanl`.   Using C768 results in `fv3jedi_var.x` aborting with the error message `stripack_addnod: colinear points`
- NOTE:  atmanlfinal only tars diagnostic files ending in suffix `.nc4`.  Some GDASApp observation yamls use `.nc` while others use `.nc4`.  Unidata recommends `.nc` ([see _What convention should be used for the names of netCDF files?_](https://docs.unidata.ucar.edu/netcdf-c/current/faq.html)).  Adhering to this recommendation will require future PRs to change g-w `atm_analysis.py` and GDASApp observation yamls.