### PR TITLE
update GSI pieces of GDAS-validation to work with GSI soil analysis (…

### DIFF
--- a/GDAS-validation/gdas_config/config.anal
+++ b/GDAS-validation/gdas_config/config.anal
@@ -50,6 +50,13 @@ export OZINFO=${FIXgfs}/gsi/global_ozinfo.txt
 export SATINFO=${FIXgfs}/gsi/global_satinfo.txt
 export OBERROR=${FIXgfs}/gsi/prepobs_errtable.global
 
+if [[ ${GSI_SOILANAL} = "YES" ]]; then
+    export hofx_2m_sfcfile=".true."
+    export reducedgrid=".false." # not possible for sfc analysis, Jeff Whitaker says it's not useful anyway
+    export paranc=".false." # temporary until sfc io coded for parance (PR being prepared by T. Gichamo)
+    export CONVINFO=${FIXgfs}/gsi/global_convinfo_2mObs.txt
+    export ANAVINFO=${FIXgfs}/gsi/global_anavinfo_soilanal.l127.txt
+fi
 
 # Use experimental dumps in EMC GFS v16 parallels
 if [[ ${RUN_ENVIR} == "emc" ]]; then

--- a/GDAS-validation/gdas_config/config_gsi.yaml
+++ b/GDAS-validation/gdas_config/config_gsi.yaml
@@ -10,6 +10,7 @@ base:
   DO_GOES: "NO"
   FHMAX_GFS: 120
   DO_VRFY_OCEANDA: "NO"
+  GSI_SOILANAL: "NO"
 
 atmanl:
   LAYOUT_X_ATMANL: 8
@@ -34,12 +35,12 @@ snowanl:
 ocnanal:
   SOCA_INPUT_FIX_DIR: "/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/data/static/72x35x25/soca"  # TODO: These need to go to glopara fix space.
   CASE_ANL: "C48"  # TODO: Check in gdasapp if used anywhere for SOCA
-  SOCA_OBS_LIST: "{{ HOMEgfs }}/sorc/gdas.cd/parm/soca/obs/obs_list.yaml"  # TODO: This is also repeated in oceanprepobs
+  SOCA_OBS_LIST: "${PARMgfs}/gdas/soca/obs/obs_list.yaml"  # TODO: This is also repeated in oceanprepobs
   SOCA_NINNER: 100
   SABER_BLOCKS_YAML: ""
   NICAS_RESOL: 1
   NICAS_GRID_SIZE: 15000
 prepoceanobs:
-  SOCA_OBS_LIST: "{{ HOMEgfs }}/sorc/gdas.cd/parm/soca/obs/obs_list.yaml"  # TODO: This is also repeated in ocnanal
-  OBSPREP_YAML: "{{ HOMEgfs }}/sorc/gdas.cd/parm/soca/obsprep/obsprep_config.yaml"
+  SOCA_OBS_LIST: "${PARMgfs}/gdas/soca/obs/obs_list.yaml"  # TODO: This is also repeated in ocnanal
+  OBSPREP_YAML: "${PARMgfs}/gdas/soca/obsprep/obsprep_config.yaml"
   DMPDIR: "/scratch1/NCEPDEV/global/glopara/data/experimental_obs"

--- a/GDAS-validation/gdas_config/exglobal_atmos_analysis.sh
+++ b/GDAS-validation/gdas_config/exglobal_atmos_analysis.sh
@@ -89,6 +89,8 @@ SENDDBN=${SENDDBN:-"NO"}
 RUN_GETGES=${RUN_GETGES:-"NO"}
 GETGESSH=${GETGESSH:-"getges.sh"}
 export gesenvir=${gesenvir:-${envir}}
+ 
+export hofx_2m_sfcfile=${hofx_2m_sfcfile:-".false."}
 
 # Observations
 OPREFIX=${OPREFIX:-""}
@@ -749,6 +751,7 @@ cat > gsiparm.anl << EOF
 /
 &OBS_INPUT
   dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=100.0,dmesh(4)=50.0,time_window_max=3.0,
+  hofx_2m_sfcfile=${hofx_2m_sfcfile},
   ${OBSINPUT}
 /
 OBS_INPUT::


### PR DESCRIPTION
The ability to perform a GSI-based soil analysis was added to g-w `develop` at [fa855ba](https://github.com/NOAA-EMC/global-workflow/commit/fa855baa851b0cb635edd1b9ae1bfed5112d41e5).  This g-w update necessitates updating GSI pieces of GDAS-validation.   This PR updates JEDI-T2O GDAS-validation to work with the g-w soil analysis changes.

Fixes #112